### PR TITLE
Adds replay resume functionality using the last played speed

### DIFF
--- a/modules/telemetry/telemetry.py
+++ b/modules/telemetry/telemetry.py
@@ -229,13 +229,14 @@ class Telemetry(Process):
                     logger.error(e.message)
                 except ReplayPlaybackError as e:
                     logger.error(e.message)
-
-            case WSCommand.REPLAY.value.STOP:
-                self.stop_replay()
             case WSCommand.REPLAY.value.PAUSE:
                 self.set_replay_speed(0.0)
+            case WSCommand.REPLAY.value.RESUME:
+                self.set_replay_speed(self.status.replay.last_played_speed)
             case WSCommand.REPLAY.value.SPEED:
                 self.set_replay_speed(float(parameters[0]))
+            case WSCommand.REPLAY.value.STOP:
+                self.stop_replay()
 
             # Record commands
             case WSCommand.RECORD.value.STOP:

--- a/modules/websocket/commands.py
+++ b/modules/websocket/commands.py
@@ -21,6 +21,7 @@ class ReplayCommands(StrEnum):
 
     PLAY = "play replay"
     PAUSE = "pause replay"
+    RESUME = "resume replay"
     SPEED = "speed replay"
     STOP = "stop replay"
 


### PR DESCRIPTION
Adds some missing functionality to resume playback of a paused replay. Currently, when paused you can do "telemetry replay play 1" and it'll start playing, but a "telemetry replay resume" is nice to have when it starts playing with the previously played speed.