### PR TITLE
Ensure rocket artwork is printed first

### DIFF
--- a/modules/misc/messages.py
+++ b/modules/misc/messages.py
@@ -5,6 +5,7 @@
 # Imports
 import datetime as dt
 import os
+from time import sleep
 
 # Constants
 ART_FILE: str = os.path.join(os.path.dirname(__file__), "launch.txt")
@@ -37,3 +38,4 @@ def print_cu_rocket(rocket_name: str, version: str) -> None:
     art = load_art()
     art = populate_fields(art, rocket_name, version)
     print(art)
+    sleep(0.1)


### PR DESCRIPTION
I noticed that sometimes when starting the ground station, the logging messages will print before the startup artwork. It seems to happen once every ten times or so, this commit resolves that.

```

C:\Users\Thomas\PycharmProjects\ground-station\venv\Scripts\python.exe C:\Users\Thomas\PycharmProjects\ground-station\main.py 
INFO:__main__:Serial.......... started.
INFO:__main__:Telemetry....... started.
INFO:__main__:WebSocket....... started.
INFO:__main__:Websocket listening on port 33845

    *      ^
          / \                                   *
         /___\              *                          
        |=   =|             
        |     |                           Matteo Golin         *
        | C U |             
        | I N |             
        |SPACE|             
   *    |     |            Samuel Dewan   *
        |     |             
       /|##!##|\                                      *
      / |##!##| \           
     /  |##!##|  \                               Thomas Selwyn 
    |  / ^ | ^ \  |         *              *
    | /  ( | )  \ |         
    |/   ( | )   \|                                 *
        ((   ))
       ((  :  ))      *     CUInSpace Avionics Telemetry Server
       ((  :  ))            Launching: No Name (Gas Propelled Launching Device)
        ((   ))             Version: 0.5.1-DEV
          ( )               Today: 07 February, 2024                *

INFO:tornado.access:101 GET /websocket (127.0.0.1) 0.00ms
INFO:modules.websocket.websocket:Client connected

```