### PR TITLE
A few tornado improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ def main():
         ),
     )
     serial.start()
-    logger.info(f"{'Serial':.<16} started.")
+    logger.info(f"{'Serial':.<13} started.")
 
     # Initialize Telemetry to parse radio packets, keep history and to log everything
     # Incoming information comes from rn2483_radio_payloads in payload format
@@ -100,7 +100,7 @@ def main():
         ),
     )
     telemetry.start()
-    logger.info(f"{'Telemetry':.<16} started.")
+    logger.info(f"{'Telemetry':.<13} started.")
 
     # Initialize Tornado websocket for UI communication
     # This is PURELY a pass through of data for connectivity. No format conversion is done here.
@@ -108,7 +108,7 @@ def main():
     # Outputs information to connected websocket clients
     websocket = Process(target=WebSocketHandler, args=(telemetry_json_output, ws_commands), daemon=True)
     websocket.start()
-    logger.info(f"{'WebSocket':.<16} started.")
+    logger.info(f"{'WebSocket':.<13} started.")
 
     while True:
         # Messages sent to main process for handling

--- a/main.py
+++ b/main.py
@@ -110,8 +110,6 @@ def main():
     websocket.start()
     logger.info(f"{'WebSocket':.<16} started.")
 
-    logger.info("Websocket listening on port 33845")
-
     while True:
         # Messages sent to main process for handling
 
@@ -120,11 +118,11 @@ def main():
             try:
                 parse_ws_command(ws_commands.get(), serial_ws_commands, telemetry_ws_commands)
             except ShutdownException:
-                logger.warning("Backend shutting down........")
+                logger.info("Ground Station shutting down...")
                 serial.terminate()
                 telemetry.terminate()
                 websocket.terminate()
-                print("Good bye.")
+                logger.info("Ground Station shutdown.")
                 exit(0)
 
 


### PR DESCRIPTION
There's a few changes in this PR, most notably that tornado (http://localhost:33845) will now respond to GET requests allowing you to view the test.html directly. Additionally, improved the websocket ping timeout cycles to reconnect faster upon restarting ground station & catches tornado failing to bind to websocket port with a graceful shutdown. This also lines up the logger messages so they align with the rocket artwork properly.