### PR TITLE
Fix spin loops

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,18 +112,17 @@ def main():
 
     while True:
         # Messages sent to main process for handling
-
-        # WS Commands
-        while not ws_commands.empty():
-            try:
-                parse_ws_command(ws_commands.get(), serial_ws_commands, telemetry_ws_commands)
-            except ShutdownException:
-                logger.info("Ground Station shutting down...")
-                serial.terminate()
-                telemetry.terminate()
-                websocket.terminate()
-                logger.info("Ground Station shutdown.")
-                exit(0)
+        try:
+            # WS Commands
+            command = ws_commands.get()
+            parse_ws_command(command, serial_ws_commands, telemetry_ws_commands)
+        except ShutdownException:
+            logger.info("Ground Station shutting down...")
+            serial.terminate()
+            telemetry.terminate()
+            websocket.terminate()
+            logger.info("Ground Station shutdown.")
+            exit(0)
 
 
 def parse_ws_command(ws_cmd: str, serial_commands: Queue[list[str]], telemetry_commands: Queue[list[str]]) -> None:

--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -60,9 +60,8 @@ class SerialManager(Process):
 
     def run(self):
         while True:
-            while not self.serial_ws_commands.empty():
-                ws_cmd = self.serial_ws_commands.get()
-                self.parse_ws_command(ws_cmd)
+            ws_cmd = self.serial_ws_commands.get()
+            self.parse_ws_command(ws_cmd)
 
     def parse_ws_command(self, ws_cmd: list[str]):
         """Parses the serial websocket commands"""

--- a/modules/telemetry/telemetry_utils.py
+++ b/modules/telemetry/telemetry_utils.py
@@ -15,7 +15,7 @@ from multiprocessing import Process, active_children
 from pathlib import Path
 
 from signal import signal, SIGTERM
-from time import time
+from time import time, sleep
 from typing import Any, TypeAlias
 
 import modules.telemetry.json_packets as jsp
@@ -144,6 +144,9 @@ class Telemetry(Process):
 
     def run(self):
         while True:
+            # Sleep for 1 ms
+            sleep(0.001)
+
             while not self.telemetry_ws_commands.empty():
                 # Parse websocket command into an enum
                 commands: list[str] = self.telemetry_ws_commands.get()


### PR DESCRIPTION
Closes #67.

This fixes several areas in the code that were set up as "spin loops"; loops that would run as fast as the CPU they're on would let them. Instead, 2/3 fixes make use of Python's `Queue.get()` to block a thread until there is a new item in the queue to process.

The third "solution" is a hack that doesn't fully solve the problem, but mitigates the effect for now. A larger refactor will be required to properly improve this hotspot.

Before this PR, 3 CPUs would be pinned while running the backend (see image below). Now, running the backend shouldn't be noticeable (assuming it's not hard for the Pi to run with the current sleep rate).

![image](https://github.com/CarletonURocketry/ground-station/assets/14791619/84f11cee-805a-4988-ba9b-fb578aaa2190)
