### PR TITLE
Fix SIGTERM methods not correctly executing

### DIFF
--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -14,13 +14,14 @@ from modules.misc.config import Config
 from modules.serial.serial_rn2483_radio import SerialRN2483Radio
 from modules.serial.serial_rn2483_emulator import SerialRN2483Emulator
 from signal import signal, SIGTERM
+from types import FrameType
 
 
 # Set up logging
 logger = logging.getLogger(__name__)
 
 
-def shutdown_sequence():
+def shutdown_sequence(signum: int, stack_frame: FrameType):
     for child in active_children():
         child.terminate()
     exit(0)

--- a/modules/telemetry/telemetry_utils.py
+++ b/modules/telemetry/telemetry_utils.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from signal import signal, SIGTERM
 from time import time, sleep
 from typing import Any, TypeAlias
+from types import FrameType
 
 import modules.telemetry.json_packets as jsp
 import modules.websocket.commands as wsc
@@ -49,7 +50,7 @@ def mission_path(mission_name: str, missions_dir: Path, file_suffix: int = 0) ->
     return missions_dir.joinpath(f"{mission_name}{'' if file_suffix == 0 else f'_{file_suffix}'}.{MISSION_EXTENSION}")
 
 
-def shutdown_sequence() -> None:
+def shutdown_sequence(signum: int, stack_frame: FrameType) -> None:
     for child in active_children():
         child.terminate()
     exit(0)


### PR DESCRIPTION
This PR fixes the shutdown methods in `telemetry_utils.py` and `serial_manager.py` by adding the correct method declaration.

Initially, on SIGTERM the shutdown methods in both of these classes are called. When a python process receives SIGTERM, the handler function receives two args which weren't previously handled. The first is the signal number as an int, the second is a stack frame object which represents the current execution frame at the time the signal was received.