### PR TITLE
Serial refactor

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "modulation": "lora",
     "frequency": 433050000,
     "power": 15,
-    "spread_factor": 9,
+    "spread_factor": 7,
     "coding_rate": "4/7",
     "bandwidth": 500,
     "preamble_len": 6,

--- a/main.py
+++ b/main.py
@@ -1,9 +1,7 @@
-# A Python-based ground station for collecting telemetry information from the CU-InSpace rocket.
-# This data is collected using UART and is transmitted to the user interface using WebSockets.
-#
-# Authors:
-# Thomas Selwyn (Devil)
-# Matteo Golin (linguini1)
+"""
+A Python-based ground station for collecting telemetry information from the CU-InSpace rocket.
+This data is collected using UART and is transmitted to the user interface using WebSockets.
+"""
 
 import multiprocessing as mp
 from multiprocessing import Process
@@ -11,11 +9,10 @@ from queue import Queue
 from re import sub
 import logging
 from typing import TypeAlias, Any
-from modules.misc.config import RadioParameters, load_config
+from modules.misc.config import load_config
 
 from modules.misc.messages import print_cu_rocket
 from modules.serial.serial_manager import SerialManager
-from modules.serial.serial_rn2483_radio import rn2483_radio_process
 from modules.telemetry.telemetry_utils import Telemetry
 from modules.websocket.websocket import WebSocketHandler
 from modules.misc.cli import parser
@@ -57,7 +54,7 @@ def main():
     serial_ws_commands: Queue[list[str]] = mp.Queue()  # type: ignore
     telemetry_ws_commands: Queue[list[str]] = mp.Queue()  # type: ignore
 
-    radio_signal_report: Queue[str] = mp.Queue()  # type: ignore
+    radio_signal_report: Queue[int] = mp.Queue()  # type: ignore
     rn2483_radio_input: Queue[str] = mp.Queue()  # type: ignore
     rn2483_radio_payloads: Queue[str] = mp.Queue()  # type: ignore
     telemetry_json_output: Queue[JSON] = mp.Queue()  # type: ignore

--- a/main.py
+++ b/main.py
@@ -11,10 +11,11 @@ from queue import Queue
 from re import sub
 import logging
 from typing import TypeAlias, Any
-from modules.misc.config import load_config
+from modules.misc.config import RadioParameters, load_config
 
 from modules.misc.messages import print_cu_rocket
 from modules.serial.serial_manager import SerialManager
+from modules.serial.serial_rn2483_radio import rn2483_radio_process
 from modules.telemetry.telemetry_utils import Telemetry
 from modules.websocket.websocket import WebSocketHandler
 from modules.misc.cli import parser

--- a/main.py
+++ b/main.py
@@ -72,15 +72,14 @@ def main():
     # Incoming information comes directly from RN2483 LoRa radio module over serial UART
     # Outputs information in hexadecimal payload format to rn2483_radio_payloads
     serial = Process(
-        target=SerialManager,
-        args=(
+        target=SerialManager(
             serial_status,
             serial_ws_commands,
             radio_signal_report,
             rn2483_radio_input,
             rn2483_radio_payloads,
             config,
-        ),
+        ).run,
     )
     serial.start()
     logger.info(f"{'Serial':.<13} started.")

--- a/modules/serial/rn2483_radio.py
+++ b/modules/serial/rn2483_radio.py
@@ -1,4 +1,9 @@
-"""Wrapper around RN2483 radio module."""
+"""
+Wrapper around RN2483 radio module.
+
+See the command data sheet for more information:
+https://ww1.microchip.com/downloads/en/DeviceDoc/RN2483-LoRa-Technology-Module-Command-Reference-User-Guide-DS40001784G.pdf
+"""
 
 from typing import Optional
 from serial import Serial, EIGHTBITS, PARITY_NONE, SerialException
@@ -55,7 +60,6 @@ def radio_write(conn: Serial, data: str) -> None:
         conn: A serial connection to the RN2483 radio.
         data: The full command or data to be sent to the RN2483 radio.
     """
-    # Must include carriage return for valid commands (see DS40001784B pg XX)
     data = str(data) + "\r\n"
     conn.flush()  # Flush the serial port
     conn.write(data.encode("utf-8"))  # Encode command_string as bytes and then transmit over serial port

--- a/modules/serial/rn2483_radio.py
+++ b/modules/serial/rn2483_radio.py
@@ -1,0 +1,188 @@
+"""Wrapper around RN2483 radio module."""
+
+from typing import Optional
+from serial import Serial, EIGHTBITS, PARITY_NONE, SerialException
+from modules.misc.config import RadioParameters
+
+RN2483_BAUD: int = 57600  # The baud rate of the RN2483 radio
+NUM_GPIO: int = 14  # Number of GPIO pins on the RN2483 module
+
+# Radio parameters
+MODULATION_MODES: list[str] = ["lora", "fsk"]
+POWER_MIN: int = -3
+POWER_MAX: int = 16
+VALID_SPREADING_FACTORS: list[int] = [7, 8, 9, 10, 11, 12]
+VALID_CODING_RATES: list[str] = ["4/5", "4/6", "4/7", "4/8"]
+VALID_BANDWIDTHS: list[int] = [125, 250, 500]
+SYNC_MIN: int = 0
+SYNC_MAX: int = 256
+PREAMBLE_MIN: int = 0
+PREAMBLE_MAX: int = 65535
+
+# Keywords for parameter setting commands of the RN2483 module over serial
+SETTING_KW: dict[str, str] = {
+    "modulation": "mod",
+    "frequency": "freq",
+    "power": "pwr",
+    "spread_factor": "sf",
+    "coding_rate": "cr",
+    "bandwidth": "bw",
+    "preamble_len": "prlen",
+    "cyclic_redundancy": "crc",
+    "iqi": "iqi",
+    "sync_word": "sync",
+}
+
+
+# Helper functions
+def wait_for_ok(conn: Serial) -> bool:
+    """
+    Check to see if 'ok' is loaded onto the serial line by the RN2483 radio. If we receive 'ok' then this
+    function returns True. If anything else is read from the serial line then this function returns False.
+
+    Arguments:
+        conn: Serial connection to an RN2483 radio.
+    """
+    rv = str(conn.readline())  # Read from serial line
+    return ("ok" in rv) or ("4294967245" in rv)
+
+
+def radio_write(conn: Serial, data: str) -> None:
+    """
+    Writes data to the RN2483 radio via UART.
+
+    Arguments:
+        conn: A serial connection to the RN2483 radio.
+        data: The full command or data to be sent to the RN2483 radio.
+    """
+    # Must include carriage return for valid commands (see DS40001784B pg XX)
+    data = str(data) + "\r\n"
+    conn.flush()  # Flush the serial port
+    conn.write(data.encode("utf-8"))  # Encode command_string as bytes and then transmit over serial port
+
+
+def radio_write_ok(conn: Serial, data: str) -> bool:
+    """
+    Writes a command to the radio and waits for a response of 'ok'.
+
+    Arguments:
+        conn: A serial connection to the radio.
+        data: The full command or data to be sent to the RN2483 radio.
+    """
+    radio_write(conn, data)
+    return wait_for_ok(conn)
+
+
+class RN2483Radio:
+    def __init__(self, serial_port: str):
+        self.serial = Serial(
+            port=serial_port,
+            timeout=1,
+            baudrate=RN2483_BAUD,
+            bytesize=EIGHTBITS,
+            parity=PARITY_NONE,
+            stopbits=1,
+            rtscts=False,
+        )
+
+    def init_gpio(self) -> None:
+        """Set all GPIO pins to input mode, thereby putting them in a state of high impedance."""
+
+        radio_write(self.serial, "sys set pinmode GPIO0 digout")
+        radio_write(self.serial, "sys set pinmode GPIO1 digout")
+        radio_write(self.serial, "sys set pinmode GPIO2 digout")
+        radio_write(self.serial, "sys set pindig GPIO0 1")
+        radio_write(self.serial, "sys set pindig GPIO1 1")
+        radio_write(self.serial, "sys set pindig GPIO2 0")
+
+        for i in range(NUM_GPIO):
+            radio_write(self.serial, f"sys set pinmode GPIO{i} digin")
+
+    def reset(self) -> bool:
+        """
+        Performs a software reset on the RN2483 radio.
+
+        Returns:
+            True if the reset was successful, false otherwise.
+        """
+        radio_write(self.serial, "sys reset")
+        wait_for_ok(self.serial)
+        return "RN2483" in str(self.serial.readline())  # Confirm from the RN2483 radio that the reset was a success
+
+    def configure(self, parameters: RadioParameters) -> None:
+        """
+        Configures the RN2483 radio with the provided radio parameters.
+
+        Arguments:
+            parameters: The parameters to set the radio with.
+
+        Raises:
+            SerialException: When a radio parameter could not be set.
+        """
+
+        for parameter, value in parameters:
+
+            # Special case where spread factor value must be preceded by sf
+            if parameter == "spread_factor":
+                value = f"sf{value}"
+
+            # Special case: boolean settings must be specified using on/off terms instead of true/false
+            if parameter == "cyclic_redundancy" or parameter == "iqi":
+                value = "on" if value else "off"
+
+            if not radio_write_ok(self.serial, f"radio set {SETTING_KW[parameter]} {value}"):
+                raise SerialException(f"Could not set parameter '{SETTING_KW[parameter]}' to '{value}'.")
+
+    def setup(self, parameters: RadioParameters) -> None:
+        """
+        Resets the RN2483 radio, initializes its GPIO pins and sets its parameters to those provided.
+
+        Arguments:
+            parameters: The parameters to set up the radio with.
+
+        Raises:
+            SerialException: When a radio parameter could not be set.
+        """
+        self.reset()
+        self.init_gpio()
+        self.configure(parameters)
+
+    def _set_rx_mode(self) -> bool:
+        """
+        Set the RN2483 radio to receive mode so that it constantly listens for transmissions.
+
+        Returns:
+            True setting receive mode worked, false otherwise.
+        """
+        if not radio_write_ok(self.serial, "radio set wdt 0"):  # Turn off watch dog timer
+            return False
+        if not radio_write_ok(self.serial, "mac pause"):  # This command must be passed before any reception can occur
+            return False
+        return radio_write_ok(self.serial, "radio rx 0")  # Command radio to go into continuous reception mode
+
+    def receive(self) -> Optional[str]:
+        """
+        Checks for new transmissions on the serial connection.
+
+        Returns:
+            A string message that the radio received (in hexadecimal digits), otherwise None.
+        """
+
+        # Enter receive mode
+        if not self._set_rx_mode():
+            return None
+
+        message = str(self.serial.readline())
+        if message == "b''":
+            return None
+        return message[10:-5]  # Trim unnecessary elements of the message
+
+    def signal_report(self) -> int:
+        """
+        Gets a signal to noise ratio report from the radio.
+
+        Returns:
+            An integer from -128 to 127 representing the signal to noise ratio of the last received packet.
+        """
+        radio_write(self.serial, "radio get snr")
+        return int(self.serial.readline())

--- a/modules/serial/rn2483_radio.py
+++ b/modules/serial/rn2483_radio.py
@@ -127,7 +127,6 @@ class RN2483Radio:
         """
 
         for parameter, value in parameters:
-
             # Special case where spread factor value must be preceded by sf
             if parameter == "spread_factor":
                 value = f"sf{value}"

--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -85,7 +85,6 @@ class SerialManager:
         signal(SIGTERM, shutdown_sequence)  # type:ignore
 
     def run(self):
-
         logger.info("Serial manager started.")
 
         while True:

--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -82,7 +82,14 @@ class SerialManager(Process):
 
         if radio_ws_cmd == "connect" and self.rn2483_radio is None:
             proposed_serial_port = ws_cmd[1]
-            if proposed_serial_port != "test":
+
+            if proposed_serial_port == "test":
+                self.rn2483_radio = Process(
+                    target=SerialRN2483Emulator,
+                    args=(self.serial_status, self.radio_signal_report, self.rn2483_radio_payloads),
+                    daemon=True,
+                )
+            else:
                 self.rn2483_radio = Process(
                     target=SerialRN2483Radio,
                     args=(
@@ -95,15 +102,11 @@ class SerialManager(Process):
                     ),
                     daemon=True,
                 )
-            else:
-                self.rn2483_radio = Process(
-                    target=SerialRN2483Emulator,
-                    args=(self.serial_status, self.radio_signal_report, self.rn2483_radio_payloads),
-                    daemon=True,
-                )
             self.rn2483_radio.start()
+
         elif radio_ws_cmd == "connect":
             logger.info("Already connected.")
+
         elif radio_ws_cmd == "disconnect" and self.rn2483_radio is not None:
             logger.info("Serial: RN2483 Radio terminating")
             self.serial_status.put("rn2483_connected False")

--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -11,7 +11,7 @@ from queue import Queue
 from multiprocessing import Process, active_children
 from serial import Serial, SerialException
 from modules.misc.config import Config
-from modules.serial.serial_rn2483_radio import SerialRN2483Radio
+from modules.serial.serial_rn2483_radio import RN2483Radio
 from modules.serial.serial_rn2483_emulator import SerialRN2483Emulator
 from signal import signal, SIGTERM
 
@@ -91,7 +91,7 @@ class SerialManager(Process):
                 )
             else:
                 self.rn2483_radio = Process(
-                    target=SerialRN2483Radio,
+                    target=RN2483Radio,
                     args=(
                         self.serial_status,
                         self.radio_signal_report,

--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -61,7 +61,7 @@ class SerialManager:
         self,
         serial_status: Queue[str],
         serial_ws_commands: Queue[list[str]],
-        radio_signal_report: Queue[str],
+        radio_signal_report: Queue[int],
         rn2483_radio_input: Queue[str],
         rn2483_radio_payloads: Queue[str],
         config: Config,
@@ -70,7 +70,7 @@ class SerialManager:
         self.serial_ports: list[str] = []
         self.serial_ws_commands: Queue[list[str]] = serial_ws_commands
 
-        self.radio_signal_report: Queue[str] = radio_signal_report
+        self.radio_signal_report: Queue[int] = radio_signal_report
 
         self.rn2483_radio_input: Queue[str] = rn2483_radio_input
         self.rn2483_radio_payloads: Queue[str] = rn2483_radio_payloads

--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -11,7 +11,7 @@ from queue import Queue
 from multiprocessing import Process, active_children
 from serial import Serial, SerialException
 from modules.misc.config import Config
-from modules.serial.serial_rn2483_radio import RN2483RadioProcess
+from modules.serial.serial_rn2483_radio import rn2483_radio_process
 from modules.serial.serial_rn2483_emulator import SerialRN2483Emulator
 from signal import signal, SIGTERM
 
@@ -26,7 +26,7 @@ def shutdown_sequence():
     exit(0)
 
 
-class SerialManager(Process):
+class SerialManager:
     def __init__(
         self,
         serial_status: Queue[str],
@@ -36,8 +36,6 @@ class SerialManager(Process):
         rn2483_radio_payloads: Queue[str],
         config: Config,
     ):
-        super().__init__()
-
         self.serial_status: Queue[str] = serial_status
         self.serial_ports: list[str] = []
         self.serial_ws_commands: Queue[list[str]] = serial_ws_commands
@@ -91,7 +89,7 @@ class SerialManager(Process):
                 )
             else:
                 self.rn2483_radio = Process(
-                    target=RN2483RadioProcess,
+                    target=rn2483_radio_process,
                     args=(
                         self.serial_status,
                         self.radio_signal_report,

--- a/modules/serial/serial_manager.py
+++ b/modules/serial/serial_manager.py
@@ -11,7 +11,7 @@ from queue import Queue
 from multiprocessing import Process, active_children
 from serial import Serial, SerialException
 from modules.misc.config import Config
-from modules.serial.serial_rn2483_radio import RN2483Radio
+from modules.serial.serial_rn2483_radio import RN2483RadioProcess
 from modules.serial.serial_rn2483_emulator import SerialRN2483Emulator
 from signal import signal, SIGTERM
 
@@ -91,7 +91,7 @@ class SerialManager(Process):
                 )
             else:
                 self.rn2483_radio = Process(
-                    target=RN2483Radio,
+                    target=RN2483RadioProcess,
                     args=(
                         self.serial_status,
                         self.radio_signal_report,

--- a/modules/serial/serial_rn2483_radio.py
+++ b/modules/serial/serial_rn2483_radio.py
@@ -3,7 +3,6 @@
 import time
 import logging
 from queue import Queue
-from multiprocessing import Process
 from serial import SerialException
 from modules.misc.config import RadioParameters
 from modules.serial.rn2483_radio import RN2483Radio
@@ -11,64 +10,48 @@ from modules.serial.rn2483_radio import RN2483Radio
 logger = logging.getLogger(__name__)
 
 
-# Helper functions
-class RN2483RadioProcess(Process):
-    def __init__(
-        self,
-        serial_status: Queue[str],
-        radio_signal_report: Queue[str],
-        rn2483_radio_input: Queue[str],
-        rn2483_radio_payloads: Queue[str],
-        serial_port: str,
-        settings: RadioParameters,
-    ):
-        super().__init__()
-        self.serial_status: Queue[str] = serial_status
-        self.radio_signal_report: Queue[str] = radio_signal_report
-        self.rn2483_radio_input: Queue[str] = rn2483_radio_input
-        self.rn2483_radio_payloads: Queue[str] = rn2483_radio_payloads
-        self.settings = settings
+def rn2483_radio_process(
+    serial_status: Queue[str],
+    radio_signal_report: Queue[str],
+    rn2483_radio_input: Queue[str],
+    rn2483_radio_payloads: Queue[str],
+    serial_port: str,
+    settings: RadioParameters,
+):
+    """Runs the primary logic for connecting to and reading from the RN2483 radio."""
+    radio = RN2483Radio(serial_port)
 
-        self.radio = RN2483Radio(serial_port)
+    logger.info(f"RN2483 Radio: Connected to {serial_port}")
+    serial_status.put("rn2483_connected True")
+    serial_status.put(f"rn2483_port {serial_port}")
 
-        logger.info(f"RN2483 Radio: Connected to {serial_port}")
-        self.serial_status.put("rn2483_connected True")
-        self.serial_status.put(f"rn2483_port {serial_port}")
+    # Set up radio
+    while True:
+        try:
+            radio.setup(settings)
+            logger.debug("Radio initialization worked.")
+            break
+        except SerialException:
+            serial_status.put("rn2483_connected False")
+            serial_status.put("rn2483_port null")
+            logger.info("RN2483 Radio: Error communicating with serial device.")
+            time.sleep(3)
 
-        self.run()
+    # Get transmissions
+    while True:
+        while not rn2483_radio_input.empty():
 
-    def run(self) -> None:
-        """
-        Runs the primary logic for connecting to and reading from the RN2483 radio.
-        """
+            command_string = rn2483_radio_input.get()
+            if command_string == "radio get snr":
+                radio_signal_report.put(str(radio.signal_report()))  # TODO: change string to integer
+            else:
+                logger.error(f"Radio command '{command_string}' is not implemented.")
 
-        # Set up radio
-        while True:
-            try:
-                self.radio.setup(self.settings)
-                logger.debug("Radio initialization worked.")
-                break
-            except SerialException:
-                self.serial_status.put("rn2483_connected False")
-                self.serial_status.put("rn2483_port null")
-                logger.info("RN2483 Radio: Error communicating with serial device.")
-                time.sleep(3)
+        # TODO: LIMIT TO ONLY AFTER THE ENTIRE BATCH IS DONE.
+        # TODO: AFTER SENDING A COMMAND TO RADIO RECALL SET_RX_MODE()
 
-        # Get transmissions
-        while True:
-            while not self.rn2483_radio_input.empty():
-
-                command_string = self.rn2483_radio_input.get()
-                if command_string == "radio get snr":
-                    self.radio_signal_report.put(str(self.radio.signal_report()))  # TODO: change string to integer
-                else:
-                    logger.error(f"Radio command '{command_string}' is not implemented.")
-
-            # TODO: LIMIT TO ONLY AFTER THE ENTIRE BATCH IS DONE.
-            # TODO: AFTER SENDING A COMMAND TO RADIO RECALL SET_RX_MODE()
-
-            # Put serial message in data queue for telemetry
-            message = self.radio.receive()
-            if message is not None:
-                logger.info(message)
-                self.rn2483_radio_payloads.put(message)
+        # Put serial message in data queue for telemetry
+        message = radio.receive()
+        if message is not None:
+            logger.info(f"Received: {message}")
+            rn2483_radio_payloads.put(message)

--- a/modules/serial/serial_rn2483_radio.py
+++ b/modules/serial/serial_rn2483_radio.py
@@ -70,4 +70,5 @@ class RN2483RadioProcess(Process):
             # Put serial message in data queue for telemetry
             message = self.radio.receive()
             if message is not None:
+                logger.info(message)
                 self.rn2483_radio_payloads.put(message)

--- a/modules/serial/serial_rn2483_radio.py
+++ b/modules/serial/serial_rn2483_radio.py
@@ -40,7 +40,6 @@ def rn2483_radio_process(
     # Get transmissions
     while True:
         while not rn2483_radio_input.empty():
-
             command_string = rn2483_radio_input.get()
             if command_string == "radio get snr":
                 radio_signal_report.put(radio.signal_report())

--- a/modules/serial/serial_rn2483_radio.py
+++ b/modules/serial/serial_rn2483_radio.py
@@ -14,10 +14,12 @@ from queue import Queue
 from multiprocessing import Process
 from typing import Optional
 from serial import Serial, SerialException, EIGHTBITS, PARITY_NONE
-
 from modules.misc.config import RadioParameters
 
-# Constants
+RN2483_BAUD: int = 57600  # The baud rate of the RN2483 radio
+NUM_GPIO: int = 14  # Number of GPIO pins on the RN2483 module
+
+# Radio parameters
 MODULATION_MODES: list[str] = ["lora", "fsk"]
 POWER_MIN: int = -3
 POWER_MAX: int = 16
@@ -28,6 +30,8 @@ SYNC_MIN: int = 0
 SYNC_MAX: int = 256
 PREAMBLE_MIN: int = 0
 PREAMBLE_MAX: int = 65535
+
+# Keywords for parameter setting commands of the RN2483 module over serial
 SETTING_KW: dict[str, str] = {
     "modulation": "mod",
     "frequency": "freq",
@@ -45,6 +49,45 @@ SETTING_KW: dict[str, str] = {
 logger = logging.getLogger(__name__)
 
 
+# Helper functions
+def wait_for_ok(conn: Serial) -> bool:
+    """
+    Check to see if 'ok' is loaded onto the serial line by the RN2483 radio. If we receive 'ok' then this
+    function returns True. If anything else is read from the serial line then this function returns False.
+
+    Arguments:
+        conn: Serial connection to an RN2483 radio.
+    """
+    rv = str(conn.readline())  # Read from serial line
+    return ("ok" in rv) or ("4294967245" in rv)
+
+
+def radio_write(conn: Serial, data: str) -> None:
+    """
+    Writes data to the RN2483 radio via UART.
+
+    Arguments:
+        conn: A serial connection to the RN2483 radio.
+        data: The full command or data to be sent to the RN2483 radio.
+    """
+    # Must include carriage return for valid commands (see DS40001784B pg XX)
+    data = str(data) + "\r\n"
+    conn.flush()  # Flush the serial port
+    conn.write(data.encode("utf-8"))  # Encode command_string as bytes and then transmit over serial port
+
+
+def radio_write_ok(conn: Serial, data: str) -> bool:
+    """
+    Writes a command to the radio and waits for a response of 'ok'.
+
+    Arguments:
+        conn: A serial connection to the radio.
+        data: The full command or data to be sent to the RN2483 radio.
+    """
+    radio_write(conn, data)
+    return wait_for_ok(conn)
+
+
 # Radio process
 class SerialRN2483Radio(Process):
     def __init__(
@@ -56,88 +99,81 @@ class SerialRN2483Radio(Process):
         serial_port: str,
         settings: RadioParameters,
     ):
-        Process.__init__(self)
-
+        super().__init__()
         self.serial_status: Queue[str] = serial_status
         self.radio_signal_report: Queue[str] = radio_signal_report
         self.rn2483_radio_input: Queue[str] = rn2483_radio_input
         self.rn2483_radio_payloads: Queue[str] = rn2483_radio_payloads
-
-        self.serial_port = serial_port
         self.settings = settings
-        self.serial: Serial
+
+        # Connect to serial port
+        self.serial = Serial(
+            port=serial_port,
+            timeout=1,
+            baudrate=RN2483_BAUD,
+            bytesize=EIGHTBITS,
+            parity=PARITY_NONE,
+            stopbits=1,
+            rtscts=False,
+        )
+
+        logger.info(f"RN2483 Radio: Connected to {self.serial.port}")
+        self.serial_status.put("rn2483_connected True")
+        self.serial_status.put(f"rn2483_port {self.serial.port}")
 
         self.run()
 
-    def run(self):
+    def run(self) -> None:
+        """
+        Runs the primary logic of the RN2483 radio.
+        """
         while True:
             try:
-                # Settings matched to RN2483 Transceiver Data Sheet's default UART settings
-                logger.info(f"RN2483 Radio: Connecting to {self.serial_port}")
-                self.serial = Serial(
-                    port=self.serial_port,
-                    timeout=1,
-                    baudrate=57600,
-                    bytesize=EIGHTBITS,
-                    parity=PARITY_NONE,
-                    stopbits=1,
-                    rtscts=False,
-                )
-                # initiate the USB serial connection
-                logger.info(f"RN2483 Radio: Connected to {self.serial_port}")
-                self.serial_status.put("rn2483_connected True")
-                self.serial_status.put(f"rn2483_port {self.serial_port}")
-
-                self.init_rn2483_radio()
+                self.setup()
                 logger.debug("Radio initialization worked.")
                 self.set_rx_mode()
                 logger.debug("Rx mode set.")
 
                 while True:
                     while not self.rn2483_radio_input.empty():
-                        _ = self.write_to_rn2483_radio(self.rn2483_radio_input.get())
+                        self.write_to_rn2483_radio(self.rn2483_radio_input.get())
                         self.set_rx_mode()
-                        # FUTURE TO DO LIMIT TO ONLY AFTER THE ENTIRE BATCH IS DONE.
-                        # AFTER SENDING A COMMAND TO RADIO RECALL SET_RX_MODE()
-
+                        # TODO: LIMIT TO ONLY AFTER THE ENTIRE BATCH IS DONE.
+                        # TODO: AFTER SENDING A COMMAND TO RADIO RECALL SET_RX_MODE()
                     self.check_for_transmissions()
-
             except SerialException:
                 self.serial_status.put("rn2483_connected False")
                 self.serial_status.put("rn2483_port null")
                 logger.info("RN2483 Radio: Error communicating with serial device.")
                 time.sleep(3)
 
-    def _read_ser(self) -> str:
-        """Read from serial line."""
-        return str(self.serial.readline())
-
     def init_gpio(self) -> None:
         """Set all GPIO pins to input mode, thereby putting them in a state of high impedance."""
 
-        _ = self.write_to_rn2483_radio("sys set pinmode GPIO0 digout")
-        _ = self.write_to_rn2483_radio("sys set pinmode GPIO1 digout")
-        _ = self.write_to_rn2483_radio("sys set pinmode GPIO2 digout")
-        _ = self.write_to_rn2483_radio("sys set pindig GPIO0 1")
-        _ = self.write_to_rn2483_radio("sys set pindig GPIO1 1")
-        _ = self.write_to_rn2483_radio("sys set pindig GPIO2 0")
+        radio_write(self.serial, "sys set pinmode GPIO0 digout")
+        radio_write(self.serial, "sys set pinmode GPIO1 digout")
+        radio_write(self.serial, "sys set pinmode GPIO2 digout")
+        radio_write(self.serial, "sys set pindig GPIO0 1")
+        radio_write(self.serial, "sys set pindig GPIO1 1")
+        radio_write(self.serial, "sys set pindig GPIO2 0")
 
-        for i in range(0, 14):
-            _ = self.write_to_rn2483_radio(f"sys set pinmode GPIO{i} digin")
+        for i in range(NUM_GPIO):
+            radio_write(self.serial, f"sys set pinmode GPIO{i} digin")
 
         logger.info("Successfully set GPIO.")
 
     def reset(self) -> bool:
-        """Performs a software reset on the RN2483 radio."""
+        """
+        Performs a software reset on the RN2483 radio.
 
-        _ = self.write_to_rn2483_radio("sys reset")
+        Returns:
+            True if the reset was successful, false otherwise.
+        """
+        radio_write(self.serial, "sys reset")
+        wait_for_ok(self.serial)
+        return "RN2483" in str(self.serial.readline())  # Confirm from the RN2483 radio that the reset was a success
 
-        ret = self._read_ser()  # Confirm from the rn2483 radio that the reset was a success
-        if "RN2483" in ret:
-            logger.info("Radio successfully reset.")
-        return "RN2483" in ret
-
-    def init_rn2483_radio(self):
+    def setup(self):
         """
         Initializes the RN2483 radio with the default parameters.
 
@@ -145,16 +181,16 @@ class SerialRN2483Radio(Process):
         Should image quality indicators (IQI) be enabled?
         """
 
-        # Restart the radio module
-        _ = self.reset()
-        logger.info("Resetting radio...")
+        self.reset()  # Restart the radio module
+        logger.info("Radio reset.")
 
         # Initialize GPIO pins
         self.init_gpio()
-        logger.info("Initializing GPIO...")
+        logger.info("GPIO initialized.")
 
         # Setting parameters
         for parameter, value in self.settings:
+
             # Special case where spread factor value must be preceded by sf
             if parameter == "spread_factor":
                 value = f"sf{value}"
@@ -163,7 +199,7 @@ class SerialRN2483Radio(Process):
             if parameter == "cyclic_redundancy" or parameter == "iqi":
                 value = "on" if value else "off"
 
-            if self.write_to_rn2483_radio(f"radio set {SETTING_KW[parameter]} {value}"):
+            if radio_write_ok(self.serial, f"radio set {SETTING_KW[parameter]} {value}"):
                 logger.debug(f"{parameter} successfully set to {value}.")
             else:
                 logger.error(f"{parameter} could not be set to {value}.")
@@ -171,84 +207,44 @@ class SerialRN2483Radio(Process):
     def write_to_rn2483_radio(self, command_string: str) -> Optional[bool]:
         """
         Writes data to the RN2483 radio via UART.
-        :author: Tarik
         :param command_string: The full command to be sent to the RN2483 radio
-
-        >> write_to_rn2483_radio("radio set pwr 7")
-        >> "ok"
-        Above example sets the radio transmission power to 7
         """
 
         data = str(command_string)
         data += "\r\n"  # Must include carriage return for valid commands (see DS40001784B pg XX)
         self.serial.flush()  # Flush the serial port
 
-        _ = self.serial.write(data.encode("utf-8"))  # Encode command_string as bytes and then transmit over serial port
+        self.serial.write(data.encode("utf-8"))  # Encode command_string as bytes and then transmit over serial port
         # Wait for response on the serial line. Return if 'ok' received
         # Sys reset gives us info about the board which we want to process differently from other commands
         if command_string not in ["sys reset", "radio get snr", "radio get rssi"]:
             # TODO: clean this up with read functions
-            return self.wait_for_ok()
+            return wait_for_ok(self.serial)
         elif command_string == "radio get snr":
-            self.radio_signal_report.put(f"snr {self._read_ser()}")
+            self.radio_signal_report.put(f"snr {str(self.serial.readline())}")
 
-    def wait_for_ok(self) -> bool:
+    def set_rx_mode(self) -> bool:
         """
-        Check to see if 'ok' is loaded onto the serial line by the RN2483 radio. If we receive 'ok' then this
-        function returns True. If anything else is read from the serial line then this function returns False.
+        Set the RN2483 radio to receive mode so that it constantly listens for transmissions.
+
+        Returns:
+            True setting receive mode worked, false otherwise.
         """
-
-        rv = str(self.serial.readline())  # Read from serial line
-
-        if "ok" in rv:
-            return True
-
-        # Returned after mac pause command.
-        if "4294967245" in rv:
-            return True
-        logger.error(f"wait_for_ok: {rv}")
-        return False
-
-    def set_rx_mode(self) -> None:
-        """Set the RN2483 radio so that it constantly listens for transmissions."""
-
-        _ = self.write_to_rn2483_radio("radio set wdt 0")  # Turn off watch dog timer
-        _ = self.write_to_rn2483_radio("mac pause")  # This command must be passed before any reception can occur
-
-        if not self.write_to_rn2483_radio("radio rx 0"):  # Command radio to go into continuous reception mode
-            logger.error("Failure putting radio into rx mode.")
+        if not radio_write_ok(self.serial, "radio set wdt 0"):  # Turn off watch dog timer
+            return False
+        if not radio_write_ok(self.serial, "mac pause"):  # This command must be passed before any reception can occur
+            return False
+        return radio_write_ok(self.serial, "radio rx 0")  # Command radio to go into continuous reception mode
 
     def check_for_transmissions(self) -> None:
-        """Checks for new transmissions on the line."""
+        """Checks for new transmissions on the serial connection."""
 
         message = str(self.serial.readline())
-
         if message == "b''":
             logger.info("Nothing received.")
             return
+
         logger.debug(f"Received a serial message: {message}")
         message = message[10:-5]  # Trim unnecessary elements of the message
         logger.debug(f"Cleaned serial message: {message}")
         self.rn2483_radio_payloads.put(message)  # Put serial message in data queue for telemetry
-
-    def _tx(self, data: str) -> None:
-        """
-        Transmit data, a method used for debugging.
-        ROCKET DOES NOT RESPOND TO TRANSMISSIONS AT THIS TIME.
-        """
-
-        _ = self.write_to_rn2483_radio("mac pause")  # Command that must be called before each transmission and receive
-
-        if not self.write_to_rn2483_radio(f"radio tx {data}"):  # Is the data we wish to transmit valid?
-            logger.error("Invalid transmission message.")
-            return
-
-        # Radio will send 'radio_tx_ok' when message has been transmitted
-        i = 0
-        while "radio_tx_ok" not in str(self._read_ser()):
-            time.sleep(0.1)  # If message not transmitted then wait for 1/10th of a second
-            i += 1
-            if i == 3:  # If we have waited 0.3 seconds, then stop waiting. Something has gone wrong.
-                logger.error("Unable to transmit message.")
-                return
-        logger.debug("Successfully sent message.")

--- a/modules/serial/serial_rn2483_radio.py
+++ b/modules/serial/serial_rn2483_radio.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def rn2483_radio_process(
     serial_status: Queue[str],
-    radio_signal_report: Queue[str],
+    radio_signal_report: Queue[int],
     rn2483_radio_input: Queue[str],
     rn2483_radio_payloads: Queue[str],
     serial_port: str,
@@ -43,7 +43,7 @@ def rn2483_radio_process(
 
             command_string = rn2483_radio_input.get()
             if command_string == "radio get snr":
-                radio_signal_report.put(str(radio.signal_report()))  # TODO: change string to integer
+                radio_signal_report.put(radio.signal_report())
             else:
                 logger.error(f"Radio command '{command_string}' is not implemented.")
 

--- a/modules/serial/serial_rn2483_radio.py
+++ b/modules/serial/serial_rn2483_radio.py
@@ -1,94 +1,18 @@
-# Serial communication to the RN2483 LoRa Radio Module
-# Outputs radio payloads from the CU-InSpace rocket
-#
-# Authors:
-# Arsalan Syed
-# Thomas Selwyn (Devil)
-# Matteo Golin (linguini1)
-# Zacchaeus Liang
+"""Process for controlling the setup of the RN2483 radio and reading its received messages."""
 
-# Imports
 import time
 import logging
 from queue import Queue
 from multiprocessing import Process
-from typing import Optional
-from serial import Serial, SerialException, EIGHTBITS, PARITY_NONE
+from serial import SerialException
 from modules.misc.config import RadioParameters
+from modules.serial.rn2483_radio import RN2483Radio
 
-RN2483_BAUD: int = 57600  # The baud rate of the RN2483 radio
-NUM_GPIO: int = 14  # Number of GPIO pins on the RN2483 module
-
-# Radio parameters
-MODULATION_MODES: list[str] = ["lora", "fsk"]
-POWER_MIN: int = -3
-POWER_MAX: int = 16
-VALID_SPREADING_FACTORS: list[int] = [7, 8, 9, 10, 11, 12]
-VALID_CODING_RATES: list[str] = ["4/5", "4/6", "4/7", "4/8"]
-VALID_BANDWIDTHS: list[int] = [125, 250, 500]
-SYNC_MIN: int = 0
-SYNC_MAX: int = 256
-PREAMBLE_MIN: int = 0
-PREAMBLE_MAX: int = 65535
-
-# Keywords for parameter setting commands of the RN2483 module over serial
-SETTING_KW: dict[str, str] = {
-    "modulation": "mod",
-    "frequency": "freq",
-    "power": "pwr",
-    "spread_factor": "sf",
-    "coding_rate": "cr",
-    "bandwidth": "bw",
-    "preamble_len": "prlen",
-    "cyclic_redundancy": "crc",
-    "iqi": "iqi",
-    "sync_word": "sync",
-}
-
-# Set up logger
 logger = logging.getLogger(__name__)
 
 
 # Helper functions
-def wait_for_ok(conn: Serial) -> bool:
-    """
-    Check to see if 'ok' is loaded onto the serial line by the RN2483 radio. If we receive 'ok' then this
-    function returns True. If anything else is read from the serial line then this function returns False.
-
-    Arguments:
-        conn: Serial connection to an RN2483 radio.
-    """
-    rv = str(conn.readline())  # Read from serial line
-    return ("ok" in rv) or ("4294967245" in rv)
-
-
-def radio_write(conn: Serial, data: str) -> None:
-    """
-    Writes data to the RN2483 radio via UART.
-
-    Arguments:
-        conn: A serial connection to the RN2483 radio.
-        data: The full command or data to be sent to the RN2483 radio.
-    """
-    # Must include carriage return for valid commands (see DS40001784B pg XX)
-    data = str(data) + "\r\n"
-    conn.flush()  # Flush the serial port
-    conn.write(data.encode("utf-8"))  # Encode command_string as bytes and then transmit over serial port
-
-
-def radio_write_ok(conn: Serial, data: str) -> bool:
-    """
-    Writes a command to the radio and waits for a response of 'ok'.
-
-    Arguments:
-        conn: A serial connection to the radio.
-        data: The full command or data to be sent to the RN2483 radio.
-    """
-    radio_write(conn, data)
-    return wait_for_ok(conn)
-
-
-class RN2483Radio(Process):
+class RN2483RadioProcess(Process):
     def __init__(
         self,
         serial_status: Queue[str],
@@ -105,35 +29,24 @@ class RN2483Radio(Process):
         self.rn2483_radio_payloads: Queue[str] = rn2483_radio_payloads
         self.settings = settings
 
-        # Connect to serial port
-        self.serial = Serial(
-            port=serial_port,
-            timeout=1,
-            baudrate=RN2483_BAUD,
-            bytesize=EIGHTBITS,
-            parity=PARITY_NONE,
-            stopbits=1,
-            rtscts=False,
-        )
+        self.radio = RN2483Radio(serial_port)
 
-        logger.info(f"RN2483 Radio: Connected to {self.serial.port}")
+        logger.info(f"RN2483 Radio: Connected to {serial_port}")
         self.serial_status.put("rn2483_connected True")
-        self.serial_status.put(f"rn2483_port {self.serial.port}")
+        self.serial_status.put(f"rn2483_port {serial_port}")
 
         self.run()
 
     def run(self) -> None:
         """
-        Runs the primary logic of the RN2483 radio.
+        Runs the primary logic for connecting to and reading from the RN2483 radio.
         """
 
         # Set up radio
         while True:
             try:
-                self.setup()
+                self.radio.setup(self.settings)
                 logger.debug("Radio initialization worked.")
-                self.set_rx_mode()
-                logger.debug("Rx mode set.")
                 break
             except SerialException:
                 self.serial_status.put("rn2483_connected False")
@@ -146,103 +59,15 @@ class RN2483Radio(Process):
             while not self.rn2483_radio_input.empty():
 
                 command_string = self.rn2483_radio_input.get()
+                if command_string == "radio get snr":
+                    self.radio_signal_report.put(str(self.radio.signal_report()))  # TODO: change string to integer
+                else:
+                    logger.error(f"Radio command '{command_string}' is not implemented.")
 
-                # Commands that respond with success message
-                if command_string not in ["sys reset", "radio get snr", "radio get rssi"]:
-                    radio_write_ok(self.serial, command_string)
-
-                # Signal to noise ratio request
-                elif command_string == "radio get snr":
-                    radio_write(self.serial, command_string)
-                    self.radio_signal_report.put(f"snr {self.serial.readline()}")
-
-                # All other requests
-                radio_write(self.serial, command_string)
-
-            self.set_rx_mode()
             # TODO: LIMIT TO ONLY AFTER THE ENTIRE BATCH IS DONE.
             # TODO: AFTER SENDING A COMMAND TO RADIO RECALL SET_RX_MODE()
-            self.check_for_transmissions()
 
-    def init_gpio(self) -> None:
-        """Set all GPIO pins to input mode, thereby putting them in a state of high impedance."""
-
-        radio_write(self.serial, "sys set pinmode GPIO0 digout")
-        radio_write(self.serial, "sys set pinmode GPIO1 digout")
-        radio_write(self.serial, "sys set pinmode GPIO2 digout")
-        radio_write(self.serial, "sys set pindig GPIO0 1")
-        radio_write(self.serial, "sys set pindig GPIO1 1")
-        radio_write(self.serial, "sys set pindig GPIO2 0")
-
-        for i in range(NUM_GPIO):
-            radio_write(self.serial, f"sys set pinmode GPIO{i} digin")
-
-        logger.info("Successfully set GPIO.")
-
-    def reset(self) -> bool:
-        """
-        Performs a software reset on the RN2483 radio.
-
-        Returns:
-            True if the reset was successful, false otherwise.
-        """
-        radio_write(self.serial, "sys reset")
-        wait_for_ok(self.serial)
-        return "RN2483" in str(self.serial.readline())  # Confirm from the RN2483 radio that the reset was a success
-
-    def setup(self):
-        """
-        Initializes the RN2483 radio with the default parameters.
-
-        Should cyclic redundancy check (CRC) be enabled?
-        Should image quality indicators (IQI) be enabled?
-        """
-
-        self.reset()  # Restart the radio module
-        logger.info("Radio reset.")
-
-        # Initialize GPIO pins
-        self.init_gpio()
-        logger.info("GPIO initialized.")
-
-        # Setting parameters
-        for parameter, value in self.settings:
-
-            # Special case where spread factor value must be preceded by sf
-            if parameter == "spread_factor":
-                value = f"sf{value}"
-
-            # Special case: boolean settings must be specified using on/off terms instead of true/false
-            if parameter == "cyclic_redundancy" or parameter == "iqi":
-                value = "on" if value else "off"
-
-            if radio_write_ok(self.serial, f"radio set {SETTING_KW[parameter]} {value}"):
-                logger.debug(f"{parameter} successfully set to {value}.")
-            else:
-                logger.error(f"{parameter} could not be set to {value}.")
-
-    def set_rx_mode(self) -> bool:
-        """
-        Set the RN2483 radio to receive mode so that it constantly listens for transmissions.
-
-        Returns:
-            True setting receive mode worked, false otherwise.
-        """
-        if not radio_write_ok(self.serial, "radio set wdt 0"):  # Turn off watch dog timer
-            return False
-        if not radio_write_ok(self.serial, "mac pause"):  # This command must be passed before any reception can occur
-            return False
-        return radio_write_ok(self.serial, "radio rx 0")  # Command radio to go into continuous reception mode
-
-    def check_for_transmissions(self) -> None:
-        """Checks for new transmissions on the serial connection."""
-
-        message = str(self.serial.readline())
-        if message == "b''":
-            logger.info("Nothing received.")
-            return
-
-        logger.debug(f"Received a serial message: {message}")
-        message = message[10:-5]  # Trim unnecessary elements of the message
-        logger.debug(f"Cleaned serial message: {message}")
-        self.rn2483_radio_payloads.put(message)  # Put serial message in data queue for telemetry
+            # Put serial message in data queue for telemetry
+            message = self.radio.receive()
+            if message is not None:
+                self.rn2483_radio_payloads.put(message)

--- a/modules/serial/serial_rn2483_radio.py
+++ b/modules/serial/serial_rn2483_radio.py
@@ -88,8 +88,7 @@ def radio_write_ok(conn: Serial, data: str) -> bool:
     return wait_for_ok(conn)
 
 
-# Radio process
-class SerialRN2483Radio(Process):
+class RN2483Radio(Process):
     def __init__(
         self,
         serial_status: Queue[str],


### PR DESCRIPTION
This pull request refactors the serial manager class and the RN2483 radio process class to be more readable.

Changes include:
- Removing the inheritance of the `Process` class from all of the process classes, since it is unnecessary when using `Process(target=x, args=(...)).start()` anyways.
- The RN2483 radio process has become a single function since it does not require a class and only the `.run()` method was relevant
- All logic for controlling the RN2483 radio has been refactored into an RN2483Radio class which exposes only the necessary public interface.
- Signal report queue now carries integers since SNR measurements are between -128 and 127.

Now it seems that the system can consistently receive transmissions as they are sent with a short delay due to serial flushing. Perhaps the delay can be reduced.