### PR TITLE
Add packet header and block header exceptions on invalid fields

### DIFF
--- a/modules/telemetry/telemetry_utils.py
+++ b/modules/telemetry/telemetry_utils.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import logging
 
 
-from modules.telemetry.v1.block import PacketHeader, BlockHeader, DeviceAddress, UnsupportedEncodingVersion
+from modules.telemetry.v1.block import PacketHeader, BlockHeader, DeviceAddress, UnsupportedEncodingVersionError
 import modules.telemetry.v1.data_block as v1db
 from modules.misc.config import Config
 
@@ -108,8 +108,8 @@ def parse_rn2483_transmission(data: str, config: Config) -> Optional[ParsedTrans
 
     try:
         pkt_hdr = PacketHeader.from_hex(data[:32])
-    except UnsupportedEncodingVersion as e:
-        logger.error(e, " skipping packet")
+    except UnsupportedEncodingVersionError as e:
+        logger.error(f"{e}, skipping packet")
         return
 
     if pkt_hdr.callsign in config.approved_callsigns:

--- a/modules/telemetry/telemetry_utils.py
+++ b/modules/telemetry/telemetry_utils.py
@@ -4,7 +4,13 @@ from typing import List, Optional
 import logging
 
 
-from modules.telemetry.v1.block import PacketHeader, BlockHeader, DeviceAddress, UnsupportedEncodingVersionError, InvalidBlockHeaderFieldValueError
+from modules.telemetry.v1.block import (
+    PacketHeader,
+    BlockHeader,
+    DeviceAddress,
+    UnsupportedEncodingVersionError,
+    InvalidBlockHeaderFieldValueError,
+)
 import modules.telemetry.v1.data_block as v1db
 from modules.misc.config import Config
 

--- a/modules/telemetry/v1/block.py
+++ b/modules/telemetry/v1/block.py
@@ -48,7 +48,7 @@ class UnsupportedEncodingVersionError(Exception):
         super().__init__(f"Unsupported encoding version: {version}")
 
 
-class InvalidBlockHeaderFieldError(Exception):
+class InvalidBlockHeaderFieldValueError(Exception):
     """Exception raised when an invalid block header field is encountered."""
 
     def __init__(self, val: str, field: str):
@@ -132,7 +132,7 @@ class BlockHeader:
             message_subtype = DataBlockSubtype(unpacked_header[2])
             destination = DeviceAddress(unpacked_header[3])
         except ValueError as e:
-            raise InvalidBlockHeaderFieldError(e.args[0].split()[0], e.args[0].split()[-1])
+            raise InvalidBlockHeaderFieldValueError(e.args[0].split()[0], e.args[0].split()[-1])
 
         return cls(length, message_type, message_subtype, destination)
 

--- a/tests/parsing/test_block_header.py
+++ b/tests/parsing/test_block_header.py
@@ -2,7 +2,7 @@
 
 # Imports
 import pytest
-from modules.telemetry.v1.block import BlockHeader, InvalidBlockHeaderFieldError
+from modules.telemetry.v1.block import BlockHeader, InvalidBlockHeaderFieldValueError
 
 
 # Fixtures
@@ -105,15 +105,15 @@ def test_parsing_header3(header3: str):
 
 def test_parsing_header1_invalid_message_type(header1_invalid_message_type: str):
     """Ensure that parsing a block header works as expected."""
-    with pytest.raises(InvalidBlockHeaderFieldError, match="Invalid block header field: 254 is not a valid value for BlockType"):
+    with pytest.raises(InvalidBlockHeaderFieldValueError, match="Invalid block header field: 254 is not a valid value for BlockType"):
         _ = BlockHeader.from_hex(header1_invalid_message_type)
 
 def test_parsing_header1_invalid_message_subtype(header1_invalid_message_subtype: str):
     """Ensure that parsing a block header works as expected."""
-    with pytest.raises(InvalidBlockHeaderFieldError, match="Invalid block header field: 254 is not a valid value for DataBlockSubtype"):
+    with pytest.raises(InvalidBlockHeaderFieldValueError, match="Invalid block header field: 254 is not a valid value for DataBlockSubtype"):
         _ = BlockHeader.from_hex(header1_invalid_message_subtype)
 
 def test_parsing_header1_invalid_destination(header1_invalid_destination: str):
     """Ensure that parsing a block header works as expected."""
-    with pytest.raises(InvalidBlockHeaderFieldError, match="Invalid block header field: 5 is not a valid value for DeviceAddress"):
+    with pytest.raises(InvalidBlockHeaderFieldValueError, match="Invalid block header field: 5 is not a valid value for DeviceAddress"):
         _ = BlockHeader.from_hex(header1_invalid_destination)

--- a/tests/parsing/test_block_header.py
+++ b/tests/parsing/test_block_header.py
@@ -2,7 +2,7 @@
 
 # Imports
 import pytest
-from modules.telemetry.v1.block import BlockHeader
+from modules.telemetry.v1.block import BlockHeader, InvalidBlockHeaderFieldError
 
 
 # Fixtures
@@ -41,6 +41,38 @@ def header3() -> str:
     """
     return "02000300"
 
+@pytest.fixture
+def header1_invalid_message_type() -> str:
+    """
+    Data block header with the following attributes:
+    length: 12 bytes
+    message type: 254
+    message sub type: 1
+    destination address: 0
+    """
+    return "02fe0100"
+
+@pytest.fixture
+def header1_invalid_message_subtype() -> str:
+    """
+    Data block header with the following attributes:
+    length: 12 bytes
+    message type: 0
+    message sub type: 254
+    destination address: 0
+    """
+    return "0200fe00"
+
+@pytest.fixture
+def header1_invalid_destination() -> str:
+    """
+    Data block header with the following attributes:
+    length: 12 bytes
+    message type: 0
+    message sub type: 1
+    destination address: 5
+    """
+    return "02000105"
 
 def test_parsing_header1(header1: str):
     """Ensure that parsing a block header works as expected."""
@@ -50,7 +82,6 @@ def test_parsing_header1(header1: str):
     assert hdr.message_type == 0
     assert hdr.message_subtype == 1
     assert hdr.destination == 0
-    assert hdr.valid is True
 
 
 def test_parsing_header2(header2: str):
@@ -61,7 +92,6 @@ def test_parsing_header2(header2: str):
     assert hdr.message_type == 0
     assert hdr.message_subtype == 2
     assert hdr.destination == 0
-    assert hdr.valid is True
 
 
 def test_parsing_header3(header3: str):
@@ -72,4 +102,18 @@ def test_parsing_header3(header3: str):
     assert hdr.message_type == 0
     assert hdr.message_subtype == 3
     assert hdr.destination == 0
-    assert hdr.valid is True
+
+def test_parsing_header1_invalid_message_type(header1_invalid_message_type: str):
+    """Ensure that parsing a block header works as expected."""
+    with pytest.raises(InvalidBlockHeaderFieldError, match="Invalid block header field: 254 is not a valid value for BlockType"):
+        _ = BlockHeader.from_hex(header1_invalid_message_type)
+
+def test_parsing_header1_invalid_message_subtype(header1_invalid_message_subtype: str):
+    """Ensure that parsing a block header works as expected."""
+    with pytest.raises(InvalidBlockHeaderFieldError, match="Invalid block header field: 254 is not a valid value for DataBlockSubtype"):
+        _ = BlockHeader.from_hex(header1_invalid_message_subtype)
+
+def test_parsing_header1_invalid_destination(header1_invalid_destination: str):
+    """Ensure that parsing a block header works as expected."""
+    with pytest.raises(InvalidBlockHeaderFieldError, match="Invalid block header field: 5 is not a valid value for DeviceAddress"):
+        _ = BlockHeader.from_hex(header1_invalid_destination)

--- a/tests/parsing/test_block_header.py
+++ b/tests/parsing/test_block_header.py
@@ -41,6 +41,7 @@ def header3() -> str:
     """
     return "02000300"
 
+
 @pytest.fixture
 def header1_invalid_message_type() -> str:
     """
@@ -51,6 +52,7 @@ def header1_invalid_message_type() -> str:
     destination address: 0
     """
     return "02fe0100"
+
 
 @pytest.fixture
 def header1_invalid_message_subtype() -> str:
@@ -63,6 +65,7 @@ def header1_invalid_message_subtype() -> str:
     """
     return "0200fe00"
 
+
 @pytest.fixture
 def header1_invalid_destination() -> str:
     """
@@ -73,6 +76,7 @@ def header1_invalid_destination() -> str:
     destination address: 5
     """
     return "02000105"
+
 
 def test_parsing_header1(header1: str):
     """Ensure that parsing a block header works as expected."""
@@ -103,17 +107,27 @@ def test_parsing_header3(header3: str):
     assert hdr.message_subtype == 3
     assert hdr.destination == 0
 
+
 def test_parsing_header1_invalid_message_type(header1_invalid_message_type: str):
     """Ensure that parsing a block header works as expected."""
-    with pytest.raises(InvalidBlockHeaderFieldValueError, match="Invalid block header field: 254 is not a valid value for BlockType"):
+    with pytest.raises(
+        InvalidBlockHeaderFieldValueError, match="Invalid block header field: 254 is not a valid value for BlockType"
+    ):
         _ = BlockHeader.from_hex(header1_invalid_message_type)
+
 
 def test_parsing_header1_invalid_message_subtype(header1_invalid_message_subtype: str):
     """Ensure that parsing a block header works as expected."""
-    with pytest.raises(InvalidBlockHeaderFieldValueError, match="Invalid block header field: 254 is not a valid value for DataBlockSubtype"):
+    with pytest.raises(
+        InvalidBlockHeaderFieldValueError,
+        match="Invalid block header field: 254 is not a valid value for DataBlockSubtype",
+    ):
         _ = BlockHeader.from_hex(header1_invalid_message_subtype)
+
 
 def test_parsing_header1_invalid_destination(header1_invalid_destination: str):
     """Ensure that parsing a block header works as expected."""
-    with pytest.raises(InvalidBlockHeaderFieldValueError, match="Invalid block header field: 5 is not a valid value for DeviceAddress"):
+    with pytest.raises(
+        InvalidBlockHeaderFieldValueError, match="Invalid block header field: 5 is not a valid value for DeviceAddress"
+    ):
         _ = BlockHeader.from_hex(header1_invalid_destination)

--- a/tests/parsing/test_full_telemetry_parsing.py
+++ b/tests/parsing/test_full_telemetry_parsing.py
@@ -9,49 +9,49 @@ config = load_config("config.json")
 # Fixtures
 
 
-# @pytest.fixture
-# def approved_callsigns() -> dict[str, str]:
-#     return config.approved_callsigns
+@pytest.fixture
+def approved_callsigns() -> dict[str, str]:
+    return config.approved_callsigns
 
 
-# @pytest.fixture
-# def valid_packet_header() -> PacketHeader:
-#     # first 32 characters of a packet
-#     hdr = "564133494e490000000c010137000000"
-#     pkt_hdr = PacketHeader.from_hex(hdr)
-#     return pkt_hdr
+@pytest.fixture
+def valid_packet_header() -> PacketHeader:
+    # first 32 characters of a packet
+    hdr = "564133494e490000000c010137000000"
+    pkt_hdr = PacketHeader.from_hex(hdr)
+    return pkt_hdr
 
 
-# @pytest.fixture
-# def non_approved_callsign() -> PacketHeader:
-#     hdr = "52415454204D4F53530c010137000000"
-#     pkt_hdr = PacketHeader.from_hex(hdr)
-#     return pkt_hdr
+@pytest.fixture
+def non_approved_callsign() -> PacketHeader:
+    hdr = "52415454204D4F53530c010137000000"
+    pkt_hdr = PacketHeader.from_hex(hdr)
+    return pkt_hdr
 
 
-# @pytest.fixture
-# def version_num_zero() -> PacketHeader:
-#     hdr = "564133494e490000000c000137000000"
-#     pkt_hdr = PacketHeader.from_hex(hdr)
-#     return pkt_hdr
+@pytest.fixture
+def version_num_zero() -> PacketHeader:
+    hdr = "564133494e490000000c000137000000"
+    pkt_hdr = PacketHeader.from_hex(hdr)
+    return pkt_hdr
 
 
-# @pytest.fixture
-# def invalid_packet_header() -> PacketHeader:
-#     hdr = "52415454204D4F53530c0b0137000000"
-#     pkt_hdr = PacketHeader.from_hex(hdr)
-#     return pkt_hdr
+@pytest.fixture
+def invalid_packet_header() -> PacketHeader:
+    hdr = "52415454204D4F53530c0b0137000000"
+    pkt_hdr = PacketHeader.from_hex(hdr)
+    return pkt_hdr
 
 
-# # Tests
+# Tests
 
 
-# # Test valid header
-# def test_is_valid_hdr(valid_packet_header: PacketHeader, approved_callsigns: dict[str, str]) -> None:
-#     assert is_valid_packet_header(valid_packet_header, approved_callsigns)
+# Test valid header
+def test_is_valid_hdr(valid_packet_header: PacketHeader, approved_callsigns: dict[str, str]) -> None:
+    assert is_valid_packet_header(valid_packet_header, approved_callsigns)
 
 
-# # Test a invalid header: unapproved call sign
+# Test a invalid header: unapproved call sign
 # def test_is_invalid_hdr1(non_approved_callsign: PacketHeader, approved_callsigns: dict[str, str]) -> None:
 #     assert not (is_valid_packet_header(non_approved_callsign, approved_callsigns))
 

--- a/tests/parsing/test_full_telemetry_parsing.py
+++ b/tests/parsing/test_full_telemetry_parsing.py
@@ -9,58 +9,58 @@ config = load_config("config.json")
 # Fixtures
 
 
-@pytest.fixture
-def approved_callsigns() -> dict[str, str]:
-    return config.approved_callsigns
+# @pytest.fixture
+# def approved_callsigns() -> dict[str, str]:
+#     return config.approved_callsigns
 
 
-@pytest.fixture
-def valid_packet_header() -> PacketHeader:
-    # first 32 characters of a packet
-    hdr = "564133494e490000000c010137000000"
-    pkt_hdr = PacketHeader.from_hex(hdr)
-    return pkt_hdr
+# @pytest.fixture
+# def valid_packet_header() -> PacketHeader:
+#     # first 32 characters of a packet
+#     hdr = "564133494e490000000c010137000000"
+#     pkt_hdr = PacketHeader.from_hex(hdr)
+#     return pkt_hdr
 
 
-@pytest.fixture
-def non_approved_callsign() -> PacketHeader:
-    hdr = "52415454204D4F53530c010137000000"
-    pkt_hdr = PacketHeader.from_hex(hdr)
-    return pkt_hdr
+# @pytest.fixture
+# def non_approved_callsign() -> PacketHeader:
+#     hdr = "52415454204D4F53530c010137000000"
+#     pkt_hdr = PacketHeader.from_hex(hdr)
+#     return pkt_hdr
 
 
-@pytest.fixture
-def version_num_zero() -> PacketHeader:
-    hdr = "564133494e490000000c000137000000"
-    pkt_hdr = PacketHeader.from_hex(hdr)
-    return pkt_hdr
+# @pytest.fixture
+# def version_num_zero() -> PacketHeader:
+#     hdr = "564133494e490000000c000137000000"
+#     pkt_hdr = PacketHeader.from_hex(hdr)
+#     return pkt_hdr
 
 
-@pytest.fixture
-def invalid_packet_header() -> PacketHeader:
-    hdr = "52415454204D4F53530c0b0137000000"
-    pkt_hdr = PacketHeader.from_hex(hdr)
-    return pkt_hdr
+# @pytest.fixture
+# def invalid_packet_header() -> PacketHeader:
+#     hdr = "52415454204D4F53530c0b0137000000"
+#     pkt_hdr = PacketHeader.from_hex(hdr)
+#     return pkt_hdr
 
 
-# Tests
+# # Tests
 
 
-# Test valid header
-def test_is_valid_hdr(valid_packet_header: PacketHeader, approved_callsigns: dict[str, str]) -> None:
-    assert is_valid_packet_header(valid_packet_header, approved_callsigns)
+# # Test valid header
+# def test_is_valid_hdr(valid_packet_header: PacketHeader, approved_callsigns: dict[str, str]) -> None:
+#     assert is_valid_packet_header(valid_packet_header, approved_callsigns)
 
 
-# Test a invalid header: unapproved call sign
-def test_is_invalid_hdr1(non_approved_callsign: PacketHeader, approved_callsigns: dict[str, str]) -> None:
-    assert not (is_valid_packet_header(non_approved_callsign, approved_callsigns))
+# # Test a invalid header: unapproved call sign
+# def test_is_invalid_hdr1(non_approved_callsign: PacketHeader, approved_callsigns: dict[str, str]) -> None:
+#     assert not (is_valid_packet_header(non_approved_callsign, approved_callsigns))
 
 
-# Test invalid header: version number 0
-def test_is_invalid_hdr2(version_num_zero: PacketHeader, approved_callsigns: dict[str, str]) -> None:
-    assert not (is_valid_packet_header(version_num_zero, approved_callsigns))
+# # Test invalid header: version number 0
+# def test_is_invalid_hdr2(version_num_zero: PacketHeader, approved_callsigns: dict[str, str]) -> None:
+#     assert not (is_valid_packet_header(version_num_zero, approved_callsigns))
 
 
-# Test invalid header: non approved callsign and incorrect version number
-def test_is_invalid_hdr3(invalid_packet_header: PacketHeader, approved_callsigns: dict[str, str]) -> None:
-    assert not (is_valid_packet_header(invalid_packet_header, approved_callsigns))
+# # Test invalid header: non approved callsign and incorrect version number
+# def test_is_invalid_hdr3(invalid_packet_header: PacketHeader, approved_callsigns: dict[str, str]) -> None:
+#     assert not (is_valid_packet_header(invalid_packet_header, approved_callsigns))

--- a/tests/parsing/test_packet_header.py
+++ b/tests/parsing/test_packet_header.py
@@ -14,7 +14,7 @@ def linguini_header() -> str:
 @pytest.fixture
 def zeta_header() -> str:
     """Returns a packet header with call sign VA3ZTA (Darwin Jull)"""
-    return "5641335A54410000000A020600040000"
+    return "5641335A54410000000A010600040000"
 
 
 @pytest.fixture
@@ -42,7 +42,7 @@ def test_zeta_header(zeta_header: str) -> None:
     assert hdr.callsign == "VA3ZTA"
     assert hdr.callzone == ""
     assert len(hdr) == 44
-    assert hdr.version == 2
+    assert hdr.version == 1
     assert hdr.src_addr == 6
     assert hdr.packet_num == 1024
 


### PR DESCRIPTION
This PR refactors the ground station parsing logic and header classes so that exceptions are thrown and caught when attempting to create a class with an invalid field value.

These values could include
- Invalid packet version for PacketHeader
- Invalid BlockType for BlockHeader
- Invalid DataBlockSubtype for BlockHeader
- Invalid DeviceAddress for BlockHeader

Any exception thrown by a header class is caught in `telemetry_utils.py`. The process will discard the entire packet upon catching an exception.

Closes #85