### PR TITLE
Have PakcetHeader `src_addr` field validate against Device Header

### DIFF
--- a/modules/telemetry/telemetry_utils.py
+++ b/modules/telemetry/telemetry_utils.py
@@ -9,7 +9,7 @@ from modules.telemetry.v1.block import (
     BlockHeader,
     DeviceAddress,
     UnsupportedEncodingVersionError,
-    InvalidBlockHeaderFieldValueError,
+    InvalidHeaderFieldValueError,
 )
 import modules.telemetry.v1.data_block as v1db
 from modules.misc.config import Config
@@ -139,7 +139,7 @@ def parse_rn2483_transmission(data: str, config: Config) -> Optional[ParsedTrans
         # Catch invalid block headers field values by skipping packet
         try:
             block_header = BlockHeader.from_hex(blocks[:8])
-        except InvalidBlockHeaderFieldValueError as e:
+        except InvalidHeaderFieldValueError as e:
             logger.error(f"{e}, skipping packet")
             return
 

--- a/tests/parsing/test_block_header.py
+++ b/tests/parsing/test_block_header.py
@@ -2,7 +2,7 @@
 
 # Imports
 import pytest
-from modules.telemetry.v1.block import BlockHeader, InvalidBlockHeaderFieldValueError
+from modules.telemetry.v1.block import BlockHeader, InvalidHeaderFieldValueError
 
 
 # Fixtures
@@ -109,25 +109,25 @@ def test_parsing_header3(header3: str):
 
 
 def test_parsing_header1_invalid_message_type(header1_invalid_message_type: str):
-    """Ensure that parsing a block header works as expected."""
+    """Ensure that parsing a block header with an invalid message type raises an error."""
     with pytest.raises(
-        InvalidBlockHeaderFieldValueError, match="Invalid block header field: 254 is not a valid value for BlockType"
+        InvalidHeaderFieldValueError, match="Invalid BlockHeader field: 254 is not a valid value for BlockType"
     ):
         _ = BlockHeader.from_hex(header1_invalid_message_type)
 
 
 def test_parsing_header1_invalid_message_subtype(header1_invalid_message_subtype: str):
-    """Ensure that parsing a block header works as expected."""
+    """Ensure that parsing a block header with an invalid message subtype raises an error."""
     with pytest.raises(
-        InvalidBlockHeaderFieldValueError,
-        match="Invalid block header field: 254 is not a valid value for DataBlockSubtype",
+        InvalidHeaderFieldValueError,
+        match="Invalid BlockHeader field: 254 is not a valid value for DataBlockSubtype",
     ):
         _ = BlockHeader.from_hex(header1_invalid_message_subtype)
 
 
 def test_parsing_header1_invalid_destination(header1_invalid_destination: str):
-    """Ensure that parsing a block header works as expected."""
+    """Ensure that parsing a block header an invalid destination raises an error."""
     with pytest.raises(
-        InvalidBlockHeaderFieldValueError, match="Invalid block header field: 5 is not a valid value for DeviceAddress"
+        InvalidHeaderFieldValueError, match="Invalid BlockHeader field: 5 is not a valid value for DeviceAddress"
     ):
         _ = BlockHeader.from_hex(header1_invalid_destination)

--- a/tests/parsing/test_packet_header.py
+++ b/tests/parsing/test_packet_header.py
@@ -2,7 +2,7 @@
 __author__ = "Matteo Golin"
 
 import pytest
-from modules.telemetry.v1.block import PacketHeader
+from modules.telemetry.v1.block import PacketHeader, InvalidHeaderFieldValueError
 
 
 @pytest.fixture
@@ -14,13 +14,19 @@ def linguini_header() -> str:
 @pytest.fixture
 def zeta_header() -> str:
     """Returns a packet header with call sign VA3ZTA (Darwin Jull)"""
-    return "5641335A54410000000A010600040000"
+    return "5641335A54410000000A01FE00040000"
 
 
 @pytest.fixture
 def devil_header() -> str:
     """Returns a packet header with call sign VE3LWN (Thomas Selwyn)"""
-    return "5645334C574E2F573568010F00000690"
+    return "5645334C574E2F57356801FF00000690"
+
+
+@pytest.fixture
+def linguini_header_invalid_src_addr() -> str:
+    """Returns a packet header with call sign VA3INI (Matteo Golin)"""
+    return "564133494e490000000c010200000000"
 
 
 def test_linguini_header(linguini_header: str) -> None:
@@ -43,7 +49,7 @@ def test_zeta_header(zeta_header: str) -> None:
     assert hdr.callzone == ""
     assert len(hdr) == 44
     assert hdr.version == 1
-    assert hdr.src_addr == 6
+    assert hdr.src_addr == 0xFE
     assert hdr.packet_num == 1024
 
 
@@ -55,5 +61,13 @@ def test_devil_header(devil_header: str) -> None:
     assert hdr.callzone == "W5"
     assert len(hdr) == 420
     assert hdr.version == 1
-    assert hdr.src_addr == 0xF
+    assert hdr.src_addr == 0xFF
     assert hdr.packet_num == 2416312320
+
+
+def test_linguini_header_invalid_src_addr(linguini_header_invalid_src_addr: str) -> None:
+    """Test that the linguini packet header with an invalid src_addr raises an error."""
+    with pytest.raises(
+        InvalidHeaderFieldValueError, match="Invalid PacketHeader field: 2 is not a valid value for DeviceAddress"
+    ):
+        _ = PacketHeader.from_hex(linguini_header_invalid_src_addr)


### PR DESCRIPTION
Closes #86 

This PR changes the PacketHeader class to validate it's `src_addr` field against the DeviceAddress enum rather than keeping it a string, it also makes the invalid field error more generic